### PR TITLE
Add gunicorn command to personal site block

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     container_name: jonny
     volumes:
       - ~/projects/personal-site:/static
+    command: gunicorn --bind 0.0.0.0:5000 -w 8 src.main:app
     networks:
       - default
     restart: on-failure


### PR DESCRIPTION
Use docker compose to specify the run command for personal-site.